### PR TITLE
fix(backend/AnalysisResource): disable stderr redirect

### DIFF
--- a/backend/app/src/main/java/backend/AnalysisResource.java
+++ b/backend/app/src/main/java/backend/AnalysisResource.java
@@ -120,7 +120,6 @@ public class AnalysisResource {
         JsonObject responseData = new JsonObject();
         try {
             ProcessBuilder processBuilder = new ProcessBuilder(command);
-            processBuilder.redirectErrorStream(true); // Combine stderr and stdout
             Process process = processBuilder.start();
 
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {


### PR DESCRIPTION
The stderr flow contains many debuging messages that are not meant for downstream applications