### PR TITLE
chore(backend/AnalysisResource): truncate the _raw param

### DIFF
--- a/backend/app/src/main/java/backend/AnalysisResource.java
+++ b/backend/app/src/main/java/backend/AnalysisResource.java
@@ -131,7 +131,7 @@ public class AnalysisResource {
 
             process.waitFor();
             String outputString = output.toString();
-            responseData.addProperty("_raw", outputString);
+            responseData.addProperty("_raw", outputString.substring(0, Math.min(outputString.length(), 160)));
             JsonElement parsedResult = gson.fromJson(outputString, JsonElement.class);
 
             responseData.add("result", parsedResult);


### PR DESCRIPTION
The _raw parameter is for debugging purpose only, and 160 characters should be enough for most cases